### PR TITLE
Adjust difficulty based on maze size

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python -m maze_generator.cli export-pdf [参数]
 
 常用参数：
 
-- `--difficulty {easy,medium,hard}`：选择难度，默认 `medium`。
+- `--difficulty {easy,medium,hard}`：选择难度，默认 `medium`。难度会根据迷宫格子总数动态调整墙体循环密度，因此自定义的尺寸会自动匹配合适的复杂度。
 - `--width --height`：自定义迷宫尺寸，覆盖难度默认尺寸。
 - `--style {classic,blueprint,night}`：选择渲染样式。
 - `--seed`：设置随机种子以便复现。

--- a/maze_generator/maze.py
+++ b/maze_generator/maze.py
@@ -183,9 +183,9 @@ def generate_maze(
     """Factory function that creates and returns a generated maze."""
 
     difficulty_profiles = {
-        "easy": {"width": 12, "height": 12, "loop_factor": 0.05},
-        "medium": {"width": 20, "height": 20, "loop_factor": 0.15},
-        "hard": {"width": 28, "height": 28, "loop_factor": 0.25},
+        "easy": {"width": 12, "height": 12, "loop_factor": 0.05, "max_cells": 12 * 12},
+        "medium": {"width": 20, "height": 20, "loop_factor": 0.15, "max_cells": 22 * 22},
+        "hard": {"width": 28, "height": 28, "loop_factor": 0.25, "max_cells": None},
     }
 
     profile = difficulty_profiles.get(difficulty)
@@ -197,11 +197,22 @@ def generate_maze(
     maze_width = width or profile["width"]
     maze_height = height or profile["height"]
 
+    cell_count = maze_width * maze_height
+    # Determine loop density dynamically based on the final maze size so that
+    # custom dimensions still produce an appropriate difficulty level.
+    for data in difficulty_profiles.values():
+        max_cells = data["max_cells"]
+        if max_cells is None or cell_count <= max_cells:
+            loop_factor = data["loop_factor"]
+            break
+    else:  # pragma: no cover - logically unreachable because "hard" has max_cells=None
+        loop_factor = profile["loop_factor"]
+
     maze = Maze(
         width=maze_width,
         height=maze_height,
         seed=seed,
-        loop_factor=profile["loop_factor"],
+        loop_factor=loop_factor,
     )
     maze.generate()
     return maze


### PR DESCRIPTION
## Summary
- update maze generation so loop density follows the final grid size, ensuring custom dimensions map to suitable difficulty
- document the new dynamic difficulty behaviour in the README

## Testing
- python -m maze_generator.cli generate --difficulty easy --width 10 --height 10 --seed 1 | head


------
https://chatgpt.com/codex/tasks/task_e_68da51454dcc8321bee55eb0bc78148e